### PR TITLE
v2.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ configtxgen --version
 # Should print the following output:
 # configtxgen:
 #  Version: 2.3.1
-#  Commit SHA: 5ea85bc54
-#  Go version: go1.14.4
+#  Commit SHA: 2f69b4222
+#  Go version: go1.14.12
 #  OS/Arch: linux/amd64
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Refer the tutorial and instructions in this article: https://medium.com/@pau.ara
 ## Install the binaries
 
 ```sh
-wget https://github.com/hyperledger/fabric/releases/download/v2.2.0/hyperledger-fabric-linux-amd64-2.2.0.tar.gz
+wget https://github.com/hyperledger/fabric/releases/download/v2.3.1/hyperledger-fabric-linux-amd64-2.3.1.tar.gz
 
-tar -xzf hyperledger-fabric-linux-amd64-2.2.0.tar.gz
+tar -xzf hyperledger-fabric-linux-amd64-2.3.1.tar.gz
 
 # Move to the bin path
 mv bin/* /bin
@@ -17,7 +17,7 @@ configtxgen --version
 
 # Should print the following output:
 # configtxgen:
-#  Version: 2.2.0
+#  Version: 2.3.1
 #  Commit SHA: 5ea85bc54
 #  Go version: go1.14.4
 #  OS/Arch: linux/amd64

--- a/chaincode/Dockerfile
+++ b/chaincode/Dockerfile
@@ -1,19 +1,40 @@
-# This image is a microservice in golang for the Degree chaincode
-FROM golang:1.14.6-alpine AS build
+FROM alpine:3.13 as base
+
+# Add CA certificates and timezone data files
+RUN apk add -U --no-cache ca-certificates tzdata
+
+# Add unprivileged user
+# Since the proxy needs to bind to a port, only root user has enough permissions to do that, 
+# otherwise applications not requiring this privilege should use a non admin user
+RUN adduser -s /bin/true -u 1000 -D -h /app app \
+    && sed -i -r "/^(app|root)/!d" /etc/group /etc/passwd \
+    && sed -i -r 's#^(.*):[^:]*$#\1:/sbin/nologin#' /etc/passwd
+
+# This image is a microservice in golang for the marbles chaincode
+FROM golang:1.15.8-alpine AS build
 
 COPY ./ /go/src/github.com/marbles
 WORKDIR /go/src/github.com/marbles
 
 # Build application
-RUN go build -o chaincode -v .
+RUN CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -trimpath -ldflags '-extldflags "-static" -w -s' -o chaincode -v .
 
 # Production ready image
 # Pass the binary to the prod image
-FROM alpine:3.11 as prod
+FROM scratch
 
-COPY --from=build /go/src/github.com/marbles/chaincode /app/chaincode
+# Add the timezone data files
+COPY --from=base /usr/share/zoneinfo /usr/share/zoneinfo
 
-USER 1000
+# Add the CA certificates
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-WORKDIR /app
-CMD ./chaincode
+# Add-in our unprivileged user
+# As explained above, the user needs admin right to bind the 53 port
+COPY --from=base /etc/passwd /etc/group /etc/shadow /etc/
+
+COPY --from=build /go/src/github.com/marbles/chaincode /chaincode
+
+USER app
+
+CMD /chaincode

--- a/chaincode/Dockerfile
+++ b/chaincode/Dockerfile
@@ -37,4 +37,4 @@ COPY --from=build /go/src/github.com/marbles/chaincode /chaincode
 
 USER app
 
-CMD /chaincode
+ENTRYPOINT ["/chaincode"]

--- a/chaincode/go.mod
+++ b/chaincode/go.mod
@@ -1,12 +1,12 @@
 module github.com/marbles
-  
+
 go 1.12
 
 require (
-        github.com/hyperledger/fabric-chaincode-go v0.0.0-20200128192331-2d899240a7ed
-        github.com/hyperledger/fabric-protos-go v0.0.0-20200124220212-e9cfc186ba7b
-        golang.org/x/net v0.0.0-20200202094626-16171245cfb2 // indirect
-        golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4 // indirect
-        golang.org/x/text v0.3.2 // indirect
-        google.golang.org/genproto v0.0.0-20200218151345-dad8c97a84f5 // indirect
+	github.com/hyperledger/fabric-chaincode-go v0.0.0-20210319203922-6b661064d4d9
+	github.com/hyperledger/fabric-protos-go v0.0.0-20210318103044-13fdee960194
+	golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4 // indirect
+	golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4 // indirect
+	golang.org/x/text v0.3.5 // indirect
+	google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6 // indirect
 )

--- a/chaincode/k8s/org1-chaincode-deployment.yaml
+++ b/chaincode/k8s/org1-chaincode-deployment.yaml
@@ -19,12 +19,12 @@ spec:
         app: chaincode-marbles-org1
     spec:
       containers:
-        - image: chaincode/marbles:1.0
+        - image: paragones/chaincode-marbles:1.0
           name: chaincode-marbles-org1
           imagePullPolicy: IfNotPresent
           env:
             - name: CHAINCODE_CCID
-              value: "marbles:d8140fbc1a0903bd88611a96c5b0077a2fdeef00a95c05bfe52e207f5f9ab79d"
+              value: "marbles:13290668038b69c1d2383175ec71c6717f1f244fe67e2392fa49ff0800f7eda4"
             - name: CHAINCODE_ADDRESS
               value: "0.0.0.0:7052"
           ports:

--- a/chaincode/k8s/org2-chaincode-deployment.yaml
+++ b/chaincode/k8s/org2-chaincode-deployment.yaml
@@ -19,12 +19,12 @@ spec:
         app: chaincode-marbles-org2
     spec:
       containers:
-        - image: chaincode/marbles:1.0
+        - image: paragones/chaincode-marbles:1.0
           name: chaincode-marbles-org2
           imagePullPolicy: IfNotPresent
           env:
             - name: CHAINCODE_CCID
-              value: "marbles:af45e0faa9676dd884a56e34b6a9bc1f7f1df04d6356aa1b2b9f123bd1d9e9e6"
+              value: "marbles:a06b77e55f6091446db06e7aa44b6bb346a1a4e937881a2d0335332528619a93"
             - name: CHAINCODE_ADDRESS
               value: "0.0.0.0:7052"
           ports:

--- a/fabcar/Dockerfile
+++ b/fabcar/Dockerfile
@@ -37,4 +37,4 @@ COPY --from=build /go/src/github.com/fabcar/chaincode /chaincode
 
 USER app
 
-CMD /chaincode
+ENTRYPOINT ["/chaincode"]

--- a/fabcar/Dockerfile
+++ b/fabcar/Dockerfile
@@ -1,19 +1,40 @@
-# This image is a microservice in golang for the Degree chaincode
-FROM golang:1.14.6-alpine AS build
+FROM alpine:3.13 as base
+
+# Add CA certificates and timezone data files
+RUN apk add -U --no-cache ca-certificates tzdata
+
+# Add unprivileged user
+# Since the proxy needs to bind to a port, only root user has enough permissions to do that, 
+# otherwise applications not requiring this privilege should use a non admin user
+RUN adduser -s /bin/true -u 1000 -D -h /app app \
+    && sed -i -r "/^(app|root)/!d" /etc/group /etc/passwd \
+    && sed -i -r 's#^(.*):[^:]*$#\1:/sbin/nologin#' /etc/passwd
+
+# This image is a microservice in golang for the marbles chaincode
+FROM golang:1.15.8-alpine AS build
 
 COPY ./ /go/src/github.com/fabcar
 WORKDIR /go/src/github.com/fabcar
 
 # Build application
-RUN go build -o chaincode -v .
+RUN CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -trimpath -ldflags '-extldflags "-static" -w -s' -o chaincode -v .
 
 # Production ready image
 # Pass the binary to the prod image
-FROM alpine:3.11 as prod
+FROM scratch
 
-COPY --from=build /go/src/github.com/fabcar/chaincode /app/chaincode
+# Add the timezone data files
+COPY --from=base /usr/share/zoneinfo /usr/share/zoneinfo
 
-USER 1000
+# Add the CA certificates
+COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-WORKDIR /app
-CMD ./chaincode
+# Add-in our unprivileged user
+# As explained above, the user needs admin right to bind the 53 port
+COPY --from=base /etc/passwd /etc/group /etc/shadow /etc/
+
+COPY --from=build /go/src/github.com/fabcar/chaincode /chaincode
+
+USER app
+
+CMD /chaincode

--- a/fabcar/fabcar.go
+++ b/fabcar/fabcar.go
@@ -22,8 +22,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"os"
+	"strconv"
 
 	"github.com/hyperledger/fabric-chaincode-go/shim"
 	"github.com/hyperledger/fabric-contract-api-go/contractapi"
@@ -55,13 +55,13 @@ func main() {
 	if err != nil {
 		fmt.Println("Error starting a new ContractApi Chaincode:", err)
 	}
-	
+
 	server := &shim.ChaincodeServer{
 		CCID:    os.Getenv("CHAINCODE_CCID"),
 		Address: os.Getenv("CHAINCODE_ADDRESS"),
 		CC:      cc,
 		TLSProps: shim.TLSProperties{
-				Disabled: true,
+			Disabled: true,
 		},
 	}
 
@@ -179,17 +179,3 @@ func (s *SmartContract) ChangeCarOwner(ctx contractapi.TransactionContextInterfa
 
 	return ctx.GetStub().PutState(carNumber, carAsBytes)
 }
-
-// func main() {
-
-// 	chaincode, err := contractapi.NewChaincode(new(SmartContract))
-
-// 	if err != nil {
-// 		fmt.Printf("Error create fabcar chaincode: %s", err.Error())
-// 		return
-// 	}
-
-// 	if err := chaincode.Start(); err != nil {
-// 		fmt.Printf("Error starting fabcar chaincode: %s", err.Error())
-// 	}
-// }

--- a/fabcar/go.mod
+++ b/fabcar/go.mod
@@ -1,12 +1,12 @@
 module github.com/fabcar
-  
+
 go 1.14
 
 require (
-        github.com/hyperledger/fabric-chaincode-go v0.0.0-20200424173110-d7076418f212
-        github.com/hyperledger/fabric-contract-api-go v1.1.0
-        golang.org/x/net v0.0.0-20200202094626-16171245cfb2 // indirect
-        golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4 // indirect
-        golang.org/x/text v0.3.2 // indirect
-        google.golang.org/genproto v0.0.0-20200218151345-dad8c97a84f5 // indirect
+	github.com/hyperledger/fabric-chaincode-go v0.0.0-20210319203922-6b661064d4d9
+	github.com/hyperledger/fabric-contract-api-go v1.1.1
+	golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4 // indirect
+	golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4 // indirect
+	golang.org/x/text v0.3.5 // indirect
+	google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6 // indirect
 )

--- a/orderer-service/orderer0-deployment.yaml
+++ b/orderer-service/orderer0-deployment.yaml
@@ -43,10 +43,14 @@ spec:
               value: prometheus
             - name: ORDERER_GENERAL_GENESISFILE
               value: /var/hyperledger/orderer/genesis.block
-            - name: ORDERER_GENERAL_GENESISMETHOD
+            - name: ORDERER_GENERAL_BOOTSTRAPMETHOD
               value: file
+            - name: ORDERER_CHANNELPARTICIPATION_ENABLED
+              value: "true"
             - name: ORDERER_GENERAL_LISTENADDRESS
               value: 0.0.0.0
+            - name: ORDERER_GENERAL_LISTENPORT
+              value: "7050"
             - name: ORDERER_GENERAL_LOCALMSPDIR
               value: /var/hyperledger/orderer/msp
             - name: ORDERER_GENERAL_LOCALMSPID
@@ -65,6 +69,18 @@ spec:
               value: /var/hyperledger/orderer/tls/server.key
             - name: ORDERER_GENERAL_CLUSTER_ROOTCAS
               value: "[/var/hyperledger/orderer/tls/ca.crt]"
+            - name: ORDERER_ADMIN_TLS_CERTIFICATE
+              value: /var/hyperledger/orderer/tls/server.crt
+            - name: ORDERER_ADMIN_TLS_ENABLED
+              value: "true"
+            - name: ORDERER_ADMIN_TLS_PRIVATEKEY
+              value: /var/hyperledger/orderer/tls/server.key
+            - name: ORDERER_ADMIN_TLS_ROOTCAS
+              value: "[/var/hyperledger/orderer/tls/ca.crt]"
+            - name: ORDERER_ADMIN_TLS_CLIENTROOTCAS
+              value: "[/var/hyperledger/orderer/tls/ca.crt]"
+            - name: ORDERER_ADMIN_LISTENADDRESS
+              value: "0.0.0.0:7053"
           image: hyperledger/fabric-orderer:amd64-2.3.1
           name: orderer
           ports:

--- a/orderer-service/orderer0-deployment.yaml
+++ b/orderer-service/orderer0-deployment.yaml
@@ -36,7 +36,7 @@ spec:
             - orderer
           env:
             - name: FABRIC_LOGGING_SPEC
-              value: DEBUG
+              value: INFO
             - name: ORDERER_OPERATIONS_LISTENADDRESS
               value: 0.0.0.0:8443
             - name: ORDERER_METRICS_PROVIDER
@@ -65,7 +65,7 @@ spec:
               value: /var/hyperledger/orderer/tls/server.key
             - name: ORDERER_GENERAL_CLUSTER_ROOTCAS
               value: "[/var/hyperledger/orderer/tls/ca.crt]"
-          image: hyperledger/fabric-orderer:amd64-2.2.0
+          image: hyperledger/fabric-orderer:amd64-2.3.1
           name: orderer
           ports:
             - containerPort: 7050

--- a/orderer-service/orderer0-svc.yaml
+++ b/orderer-service/orderer0-svc.yaml
@@ -12,6 +12,9 @@ spec:
     - name: "orderer"
       port: 7050
       targetPort: 7050
+    - name: "admin"
+      port: 7053
+      targetPort: 7053
   selector:
     app: orderer0
 ---

--- a/orderer-service/orderer1-deployment.yaml
+++ b/orderer-service/orderer1-deployment.yaml
@@ -43,10 +43,14 @@ spec:
               value: prometheus
             - name: ORDERER_GENERAL_GENESISFILE
               value: /var/hyperledger/orderer/genesis.block
-            - name: ORDERER_GENERAL_GENESISMETHOD
+            - name: ORDERER_GENERAL_BOOTSTRAPMETHOD
               value: file
+            - name: ORDERER_CHANNELPARTICIPATION_ENABLED
+              value: "true"
             - name: ORDERER_GENERAL_LISTENADDRESS
               value: 0.0.0.0
+            - name: ORDERER_GENERAL_LISTENPORT
+              value: "7050"
             - name: ORDERER_GENERAL_LOCALMSPDIR
               value: /var/hyperledger/orderer/msp
             - name: ORDERER_GENERAL_LOCALMSPID
@@ -65,6 +69,18 @@ spec:
               value: /var/hyperledger/orderer/tls/server.key
             - name: ORDERER_GENERAL_CLUSTER_ROOTCAS
               value: "[/var/hyperledger/orderer/tls/ca.crt]"
+            - name: ORDERER_ADMIN_TLS_CERTIFICATE
+              value: /var/hyperledger/orderer/tls/server.crt
+            - name: ORDERER_ADMIN_TLS_ENABLED
+              value: "true"
+            - name: ORDERER_ADMIN_TLS_PRIVATEKEY
+              value: /var/hyperledger/orderer/tls/server.key
+            - name: ORDERER_ADMIN_TLS_ROOTCAS
+              value: "[/var/hyperledger/orderer/tls/ca.crt]"
+            - name: ORDERER_ADMIN_TLS_CLIENTROOTCAS
+              value: "[/var/hyperledger/orderer/tls/ca.crt]"
+            - name: ORDERER_ADMIN_LISTENADDRESS
+              value: "0.0.0.0:7053"
           image: hyperledger/fabric-orderer:amd64-2.3.1
           name: orderer
           ports:

--- a/orderer-service/orderer1-deployment.yaml
+++ b/orderer-service/orderer1-deployment.yaml
@@ -36,7 +36,7 @@ spec:
             - orderer
           env:
             - name: FABRIC_LOGGING_SPEC
-              value: DEBUG
+              value: INFO
             - name: ORDERER_OPERATIONS_LISTENADDRESS
               value: 0.0.0.0:8443
             - name: ORDERER_METRICS_PROVIDER
@@ -65,7 +65,7 @@ spec:
               value: /var/hyperledger/orderer/tls/server.key
             - name: ORDERER_GENERAL_CLUSTER_ROOTCAS
               value: "[/var/hyperledger/orderer/tls/ca.crt]"
-          image: hyperledger/fabric-orderer:amd64-2.2.0
+          image: hyperledger/fabric-orderer:amd64-2.3.1
           name: orderer
           ports:
             - containerPort: 7050

--- a/orderer-service/orderer1-svc.yaml
+++ b/orderer-service/orderer1-svc.yaml
@@ -12,6 +12,9 @@ spec:
     - name: "orderer"
       port: 7050
       targetPort: 7050
+    - name: "admin"
+      port: 7053
+      targetPort: 7053
   selector:
     app: orderer1
 ---

--- a/orderer-service/orderer2-deployment.yaml
+++ b/orderer-service/orderer2-deployment.yaml
@@ -43,10 +43,14 @@ spec:
               value: prometheus
             - name: ORDERER_GENERAL_GENESISFILE
               value: /var/hyperledger/orderer/genesis.block
-            - name: ORDERER_GENERAL_GENESISMETHOD
+            - name: ORDERER_GENERAL_BOOTSTRAPMETHOD
               value: file
+            - name: ORDERER_CHANNELPARTICIPATION_ENABLED
+              value: "true"
             - name: ORDERER_GENERAL_LISTENADDRESS
               value: 0.0.0.0
+            - name: ORDERER_GENERAL_LISTENPORT
+              value: "7050"
             - name: ORDERER_GENERAL_LOCALMSPDIR
               value: /var/hyperledger/orderer/msp
             - name: ORDERER_GENERAL_LOCALMSPID
@@ -65,6 +69,18 @@ spec:
               value: /var/hyperledger/orderer/tls/server.key
             - name: ORDERER_GENERAL_CLUSTER_ROOTCAS
               value: "[/var/hyperledger/orderer/tls/ca.crt]"
+            - name: ORDERER_ADMIN_TLS_CERTIFICATE
+              value: /var/hyperledger/orderer/tls/server.crt
+            - name: ORDERER_ADMIN_TLS_ENABLED
+              value: "true"
+            - name: ORDERER_ADMIN_TLS_PRIVATEKEY
+              value: /var/hyperledger/orderer/tls/server.key
+            - name: ORDERER_ADMIN_TLS_ROOTCAS
+              value: "[/var/hyperledger/orderer/tls/ca.crt]"
+            - name: ORDERER_ADMIN_TLS_CLIENTROOTCAS
+              value: "[/var/hyperledger/orderer/tls/ca.crt]"
+            - name: ORDERER_ADMIN_LISTENADDRESS
+              value: "0.0.0.0:7053"
           image: hyperledger/fabric-orderer:amd64-2.3.1
           name: orderer
           ports:

--- a/orderer-service/orderer2-deployment.yaml
+++ b/orderer-service/orderer2-deployment.yaml
@@ -36,7 +36,7 @@ spec:
             - orderer
           env:
             - name: FABRIC_LOGGING_SPEC
-              value: DEBUG
+              value: INFO
             - name: ORDERER_OPERATIONS_LISTENADDRESS
               value: 0.0.0.0:8443
             - name: ORDERER_METRICS_PROVIDER
@@ -65,7 +65,7 @@ spec:
               value: /var/hyperledger/orderer/tls/server.key
             - name: ORDERER_GENERAL_CLUSTER_ROOTCAS
               value: "[/var/hyperledger/orderer/tls/ca.crt]"
-          image: hyperledger/fabric-orderer:amd64-2.2.0
+          image: hyperledger/fabric-orderer:amd64-2.3.1
           name: orderer
           ports:
             - containerPort: 7050

--- a/orderer-service/orderer2-svc.yaml
+++ b/orderer-service/orderer2-svc.yaml
@@ -12,6 +12,9 @@ spec:
     - name: "orderer"
       port: 7050
       targetPort: 7050
+    - name: "admin"
+      port: 7053
+      targetPort: 7053
   selector:
     app: orderer2
 ---

--- a/org1/org1-ca-deployment.yaml
+++ b/org1/org1-ca-deployment.yaml
@@ -22,9 +22,7 @@ spec:
         - args:
             - sh
             - -c
-            - fabric-ca-server start --ca.certfile /etc/hyperledger/fabric-ca-server-config/ca.org1-cert.pem
-              --ca.keyfile /etc/hyperledger/fabric-ca-server-config/priv_sk
-              -b admin:adminpw -d
+            - fabric-ca-server start -b admin:adminpw -d
           env:
             - name: FABRIC_CA_HOME
               value: /etc/hyperledger/fabric-ca-server
@@ -36,7 +34,15 @@ spec:
               value: "true"
             - name: FABRIC_CA_SERVER_TLS_KEYFILE
               value: /etc/hyperledger/fabric-ca-server-config/priv_sk
-          image: hyperledger/fabric-ca:amd64-1.4.7
+            - name: FABRIC_CA_SERVER_CA_KEYFILE
+              value: /etc/hyperledger/fabric-ca-server-config/priv_sk
+            - name: FABRIC_CA_SERVER_CA_CERTFILE
+              value: /etc/hyperledger/fabric-ca-server-config/ca.org1-cert.pem
+            - name: FABRIC_CA_SERVER_OPERATIONS_LISTENADDRESS
+              value: 0.0.0.0:8443
+            - name: FABRIC_CA_SERVER_METRICS_PROVIDER
+              value: prometheus
+          image: hyperledger/fabric-ca:amd64-1.4.9
           name: ca-org1
           ports:
             - containerPort: 7054

--- a/org1/org1-cli-deployment.yaml
+++ b/org1/org1-cli-deployment.yaml
@@ -42,12 +42,10 @@ spec:
               value: /opt/gopath
             - name: ORDERER_CA
               value: /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/consortium/orderers/orderer0/msp/tlscacerts/tlsca.consortium-cert.pem
-          image: hyperledger/fabric-tools:amd64-2.2.0
+          image: hyperledger/fabric-tools:amd64-2.3.1
           name: cli
           tty: true
           volumeMounts:
-            # - mountPath: /host/var/run/
-            #   name: cli-claim0
             - mountPath: /opt/gopath/src/github.com/marbles/
               name: cli-claim1
             - mountPath: /opt/gopath/src/github.com/hyperledger/fabric/peer/scripts/channel-artifacts
@@ -59,10 +57,6 @@ spec:
           workingDir: /opt/gopath/src/github.com/hyperledger/fabric/peer
       restartPolicy: Always
       volumes:
-        # - name: cli-claim0
-        #   hostPath:
-        #     path: /var/run/
-        #     type: Directory
         - name: cli-claim1
           hostPath:
             path: /home/fabric-external-chaincodes/chaincode

--- a/org1/org1-peer0-deployment.yaml
+++ b/org1/org1-peer0-deployment.yaml
@@ -50,13 +50,11 @@ spec:
               value: /etc/hyperledger/fabric/tls/server.key
             - name: CORE_PEER_TLS_ROOTCERT_FILE
               value: /etc/hyperledger/fabric/tls/ca.crt
-            - name: CORE_VM_ENDPOINT
-              value: http://localhost:2375
             - name: CORE_OPERATIONS_LISTENADDRESS
               value: 0.0.0.0:9443
             - name: CORE_METRICS_PROVIDER
               value: prometheus
-          image: hyperledger/fabric-peer:amd64-2.2.0
+          image: hyperledger/fabric-peer:amd64-2.3.1
           name: peer0
           ports:
             - containerPort: 7051

--- a/org2/org2-ca-deployment.yaml
+++ b/org2/org2-ca-deployment.yaml
@@ -22,9 +22,7 @@ spec:
         - args:
             - sh
             - -c
-            - fabric-ca-server start --ca.certfile /etc/hyperledger/fabric-ca-server-config/ca.org2-cert.pem
-              --ca.keyfile /etc/hyperledger/fabric-ca-server-config/priv_sk
-              -b admin:adminpw -d
+            - fabric-ca-server start -b admin:adminpw -d
           env:
             - name: FABRIC_CA_HOME
               value: /etc/hyperledger/fabric-ca-server
@@ -36,7 +34,15 @@ spec:
               value: "true"
             - name: FABRIC_CA_SERVER_TLS_KEYFILE
               value: /etc/hyperledger/fabric-ca-server-config/priv_sk
-          image: hyperledger/fabric-ca:amd64-1.4.7
+            - name: FABRIC_CA_SERVER_CA_KEYFILE
+              value: /etc/hyperledger/fabric-ca-server-config/priv_sk
+            - name: FABRIC_CA_SERVER_CA_CERTFILE
+              value: /etc/hyperledger/fabric-ca-server-config/ca.org2-cert.pem
+            - name: FABRIC_CA_SERVER_OPERATIONS_LISTENADDRESS
+              value: 0.0.0.0:8443
+            - name: FABRIC_CA_SERVER_METRICS_PROVIDER
+              value: prometheus
+          image: hyperledger/fabric-ca:amd64-1.4.9
           name: ca-org2
           ports:
             - containerPort: 7054

--- a/org2/org2-cli-deployment.yaml
+++ b/org2/org2-cli-deployment.yaml
@@ -42,12 +42,10 @@ spec:
               value: /opt/gopath
             - name: ORDERER_CA
               value: /opt/gopath/src/github.com/hyperledger/fabric/peer/crypto/ordererOrganizations/consortium/orderers/orderer0/msp/tlscacerts/tlsca.consortium-cert.pem
-          image: hyperledger/fabric-tools:amd64-2.2.0
+          image: hyperledger/fabric-tools:amd64-2.3.1
           name: cli
           tty: true
           volumeMounts:
-            # - mountPath: /host/var/run/
-            #   name: cli-claim0
             - mountPath: /opt/gopath/src/github.com/marbles/
               name: cli-claim1
             - mountPath: /opt/gopath/src/github.com/hyperledger/fabric/peer/scripts/channel-artifacts
@@ -59,10 +57,6 @@ spec:
           workingDir: /opt/gopath/src/github.com/hyperledger/fabric/peer
       restartPolicy: Always
       volumes:
-        # - name: cli-claim0
-        #   hostPath:
-        #     path: /var/run/
-        #     type: Directory
         - name: cli-claim1
           hostPath:
             path: /home/fabric-external-chaincodes/chaincode

--- a/org2/org2-peer0-deployment.yaml
+++ b/org2/org2-peer0-deployment.yaml
@@ -50,13 +50,11 @@ spec:
               value: /etc/hyperledger/fabric/tls/server.key
             - name: CORE_PEER_TLS_ROOTCERT_FILE
               value: /etc/hyperledger/fabric/tls/ca.crt
-            - name: CORE_VM_ENDPOINT
-              value: http://localhost:2375
             - name: CORE_OPERATIONS_LISTENADDRESS
               value: 0.0.0.0:9443
             - name: CORE_METRICS_PROVIDER
               value: prometheus
-          image: hyperledger/fabric-peer:amd64-2.2.0
+          image: hyperledger/fabric-peer:amd64-2.3.1
           name: peer0
           ports:
             - containerPort: 7051


### PR DESCRIPTION
# Main Changes made

- Update all components to v2.3.1 of Hyperledger Fabric
- Refactor Chaincode Dockerfile to use no-root scratch image to enable an even more secure image
- Updated orderer yaml deployment specs to enable channel participation feature API
- Pushed the marbles and fabcar docker images to Docker Hub
