### PR TITLE
Update Chaincodes Dockerfile, go version and dependencies

### DIFF
--- a/chaincode/Dockerfile
+++ b/chaincode/Dockerfile
@@ -1,15 +1,4 @@
-FROM alpine:3.13 as base
-
-# Add CA certificates and timezone data files
-RUN apk add -U --no-cache ca-certificates tzdata
-
-# Add unprivileged user
-RUN adduser -s /bin/true -u 1000 -D -h /app app \
-    && sed -i -r "/^(app|root)/!d" /etc/group /etc/passwd \
-    && sed -i -r 's#^(.*):[^:]*$#\1:/sbin/nologin#' /etc/passwd
-
-# This image is a microservice in golang for the marbles chaincode
-FROM golang:1.15.8-alpine AS build
+FROM golang:1.20-alpine AS build
 
 COPY ./ /go/src/github.com/marbles
 WORKDIR /go/src/github.com/marbles
@@ -19,19 +8,10 @@ RUN CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -trimpath -ldflags '-extldfla
 
 # Production ready image
 # Pass the binary to the prod image
-FROM scratch
+FROM gcr.io/distroless/static
 
-# Add the timezone data files
-COPY --from=base /usr/share/zoneinfo /usr/share/zoneinfo
+USER nonroot:nonroot
 
-# Add the CA certificates
-COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-
-# Add-in our unprivileged user
-COPY --from=base /etc/passwd /etc/group /etc/shadow /etc/
-
-COPY --from=build /go/src/github.com/marbles/chaincode /chaincode
-
-USER app
+COPY --from=build --chown=nonroot:nonroot /go/src/github.com/marbles/chaincode /chaincode
 
 ENTRYPOINT ["/chaincode"]

--- a/chaincode/go.mod
+++ b/chaincode/go.mod
@@ -1,12 +1,18 @@
 module github.com/marbles
 
-go 1.12
+go 1.20
 
 require (
-	github.com/hyperledger/fabric-chaincode-go v0.0.0-20210319203922-6b661064d4d9
-	github.com/hyperledger/fabric-protos-go v0.0.0-20210318103044-13fdee960194
-	golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4 // indirect
-	golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4 // indirect
-	golang.org/x/text v0.3.5 // indirect
-	google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6 // indirect
+	github.com/hyperledger/fabric-chaincode-go v0.0.0-20230228194215-b84622ba6a7a
+	github.com/hyperledger/fabric-protos-go v0.3.0
+)
+
+require (
+	github.com/golang/protobuf v1.5.3 // indirect
+	golang.org/x/net v0.11.0 // indirect
+	golang.org/x/sys v0.9.0 // indirect
+	golang.org/x/text v0.10.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230526203410-71b5a4ffd15e // indirect
+	google.golang.org/grpc v1.55.0 // indirect
+	google.golang.org/protobuf v1.30.0 // indirect
 )

--- a/fabcar/Dockerfile
+++ b/fabcar/Dockerfile
@@ -1,15 +1,4 @@
-FROM alpine:3.13 as base
-
-# Add CA certificates and timezone data files
-RUN apk add -U --no-cache ca-certificates tzdata
-
-# Add unprivileged user
-RUN adduser -s /bin/true -u 1000 -D -h /app app \
-    && sed -i -r "/^(app|root)/!d" /etc/group /etc/passwd \
-    && sed -i -r 's#^(.*):[^:]*$#\1:/sbin/nologin#' /etc/passwd
-
-# This image is a microservice in golang for the marbles chaincode
-FROM golang:1.15.8-alpine AS build
+FROM golang:1.20-alpine AS build
 
 COPY ./ /go/src/github.com/fabcar
 WORKDIR /go/src/github.com/fabcar
@@ -19,19 +8,10 @@ RUN CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -trimpath -ldflags '-extldfla
 
 # Production ready image
 # Pass the binary to the prod image
-FROM scratch
+FROM gcr.io/distroless/static
 
-# Add the timezone data files
-COPY --from=base /usr/share/zoneinfo /usr/share/zoneinfo
+USER nonroot:nonroot
 
-# Add the CA certificates
-COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-
-# Add-in our unprivileged user
-COPY --from=base /etc/passwd /etc/group /etc/shadow /etc/
-
-COPY --from=build /go/src/github.com/fabcar/chaincode /chaincode
-
-USER app
+COPY --from=build --chown=nonroot:nonroot /go/src/github.com/fabcar/chaincode /chaincode
 
 ENTRYPOINT ["/chaincode"]

--- a/fabcar/go.mod
+++ b/fabcar/go.mod
@@ -1,12 +1,34 @@
 module github.com/fabcar
 
-go 1.14
+go 1.20
 
 require (
-	github.com/hyperledger/fabric-chaincode-go v0.0.0-20210319203922-6b661064d4d9
-	github.com/hyperledger/fabric-contract-api-go v1.1.1
-	golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4 // indirect
-	golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4 // indirect
-	golang.org/x/text v0.3.5 // indirect
-	google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6 // indirect
+	github.com/hyperledger/fabric-chaincode-go v0.0.0-20230228194215-b84622ba6a7a
+	github.com/hyperledger/fabric-contract-api-go v1.2.1
+)
+
+require (
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/jsonreference v0.20.0 // indirect
+	github.com/go-openapi/spec v0.20.8 // indirect
+	github.com/go-openapi/swag v0.21.1 // indirect
+	github.com/gobuffalo/envy v1.10.1 // indirect
+	github.com/gobuffalo/packd v1.0.1 // indirect
+	github.com/gobuffalo/packr v1.30.1 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/hyperledger/fabric-protos-go v0.3.0 // indirect
+	github.com/joho/godotenv v1.4.0 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/rogpeppe/go-internal v1.8.1 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+	golang.org/x/net v0.11.0 // indirect
+	golang.org/x/sys v0.9.0 // indirect
+	golang.org/x/text v0.10.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230526203410-71b5a4ffd15e // indirect
+	google.golang.org/grpc v1.55.0 // indirect
+	google.golang.org/protobuf v1.30.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )


### PR DESCRIPTION
Updating Chaincodes codebase in order to simplify maintenance:

- Refactoring Dockerfiles so that no longer we craft most of the final production image. Final production image switched to distroless/static as it recreates almost the final shape of the image as it had before
- Update to newest go version from 1.12 to 1.20
- Updated all dependencies so that fixes all dependabot security alerts